### PR TITLE
Setup CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: php
+php:
+  - '5.6'
+  - '7.1'
+script: php tests/run.php


### PR DESCRIPTION
Code is tested against the version of PHP currently supported by Tuleap (5.6)
and the most recent one accessible on CentOS (7.1).


You find with this configuration here: https://travis-ci.org/LeSuisse/ForgeUpgrade/builds/329437463