### PR TITLE
Rely on rh-php56 to run forgeupgrade

### DIFF
--- a/forgeupgrade
+++ b/forgeupgrade
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/share/forgeupgrade/forgeupgrade.php $@
+/opt/rh/rh-php56/root/usr/bin/php /usr/share/forgeupgrade/forgeupgrade.php $@

--- a/forgeupgrade.spec
+++ b/forgeupgrade.spec
@@ -11,6 +11,7 @@ Group: Development/Tools
 URL: http://github.com/vaceletm/ForgeUpgrade
 Source0: %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+Requires: rh-php56-php-cli, rh-php56-php-pdo
 
 %description
 ForgeUpgrade is an application data (files or databases) upgrade automation


### PR DESCRIPTION
According to PHPCompatibility and some functionnal tests,
forgeupgrade runs fine with PHP 5.6.

This solves [request #11011](https://tuleap.net/plugins/tracker/?aid=11011): forgeupgrade no longer works on system without php 5.3